### PR TITLE
chore: remove non-owned account (lndev/leonel.ngoya) from the app

### DIFF
--- a/components/common/issues/issue-line.tsx
+++ b/components/common/issues/issue-line.tsx
@@ -22,7 +22,6 @@ export function IssueLine({
 }: { issue: Issue; layoutId?: boolean }) {
   return (
     <motion.div
-      //href={`/circle/issue/${issue.identifier}`}
       {...(layoutId && { layoutId: `issue-line-${issue.identifier}` })}
       className="w-full flex items-center justify-start h-11 px-6 hover:bg-sidebar/50"
     >

--- a/components/common/issues/issue-line.tsx
+++ b/components/common/issues/issue-line.tsx
@@ -22,7 +22,7 @@ export function IssueLine({
 }: { issue: Issue; layoutId?: boolean }) {
   return (
     <motion.div
-      //href={`/lndev-ui/issue/${issue.identifier}`}
+      //href={`/circle/issue/${issue.identifier}`}
       {...(layoutId && { layoutId: `issue-line-${issue.identifier}` })}
       className="w-full flex items-center justify-start h-11 px-6 hover:bg-sidebar/50"
     >

--- a/components/common/issues/project-badge.tsx
+++ b/components/common/issues/project-badge.tsx
@@ -13,7 +13,7 @@ import { getIconFromString } from '~/utils/icon-utils';
 export function ProjectBadge({ project }: { project: Project }) {
   return (
     <Link
-      href={'/lndev-ui/projects/all'}
+      href={'/circle/projects/all'}
       className="flex items-center justify-center gap-.5"
     >
       <Badge

--- a/components/layout/sidebar/app-sidebar-client.tsx
+++ b/components/layout/sidebar/app-sidebar-client.tsx
@@ -4,21 +4,17 @@ import {
   Box,
   ContactRound,
   FolderKanban,
-  Github,
   Inbox,
   UserRound,
-  X,
   type LucideIcon,
 } from 'lucide-react';
 import * as React from 'react';
-import Link from 'next/link';
 
 import { HelpButton } from '~/components/layout/sidebar/help-button';
 import { NavInbox } from '~/components/layout/sidebar/nav-inbox';
 import { NavTeams } from '~/components/layout/sidebar/nav-teams';
 import { NavWorkspace } from '~/components/layout/sidebar/nav-workspace';
 import { UserMenu } from '~/components/account/user-menu';
-import { Button } from '~/components/ui/button';
 import {
   Sidebar,
   SidebarContent,
@@ -81,8 +77,6 @@ export function AppSidebarClient({
   workspaceData,
   ...props
 }: AppSidebarClientProps) {
-  const [open, setOpen] = React.useState(true);
-
   // atomの更新関数を取得
   const setStatuses = useSetAtom(statusesAtom);
   const setProjects = useSetAtom(projectsAtom);
@@ -170,53 +164,8 @@ export function AppSidebarClient({
         <NavTeams items={teams} />
       </SidebarContent>
       <SidebarFooter>
-        <div className="w-full flex flex-col gap-2">
-          {open && (
-            <div className="group/sidebar relative flex flex-col gap-2 rounded-lg border p-4 text-sm w-full">
-              <button
-                className="absolute top-2.5 right-2 z-10 cursor-pointer"
-                onClick={() => setOpen(!open)}
-                type="button"
-              >
-                <X className="size-4" />
-              </button>
-              <div className="text-balance text-lg font-semibold leading-tight group-hover/sidebar:underline">
-                lndevによる優れたコンポーネント
-              </div>
-              <div>
-                開発プロセスを効率化するための、小さくて優れたコンポーネントの楽しいコレクション。
-              </div>
-              <Link
-                target="_blank"
-                rel="noreferrer"
-                className="absolute inset-0"
-                href="https://ui.lndev.me"
-              >
-                <span className="sr-only">Vercelにデプロイ</span>
-              </Link>
-              <Button size="sm" className="w-full">
-                <Link
-                  href="https://ui.lndev.me"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  ui.lndev.me
-                </Link>
-              </Button>
-            </div>
-          )}
-          <div className="w-full flex items-center justify-between">
-            <HelpButton />
-            <Button size="icon" variant="secondary" asChild>
-              <Link
-                href="https://github.com/ln-dev7/circle"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                <Github className="size-4" />
-              </Link>
-            </Button>
-          </div>
+        <div className="w-full flex items-center justify-between">
+          <HelpButton />
         </div>
       </SidebarFooter>
     </Sidebar>

--- a/components/layout/sidebar/app-sidebar.tsx
+++ b/components/layout/sidebar/app-sidebar.tsx
@@ -41,17 +41,17 @@ const data = {
   workspace: [
     {
       name: 'チーム',
-      url: '/lndev-ui/teams',
+      url: '/circle/teams',
       icon: 'ContactRound', // コンポーネント関数からアイコン名の文字列に変更
     },
     {
       name: 'プロジェクト',
-      url: '/lndev-ui/projects',
+      url: '/circle/projects',
       icon: 'Box', // コンポーネント関数からアイコン名の文字列に変更
     },
     {
       name: 'メンバー',
-      url: '/lndev-ui/members',
+      url: '/circle/members',
       icon: 'UserRound', // コンポーネント関数からアイコン名の文字列に変更
     },
   ] as NavItem[],

--- a/components/layout/sidebar/create-new-issue/index.tsx
+++ b/components/layout/sidebar/create-new-issue/index.tsx
@@ -59,7 +59,7 @@ export function CreateNewIssue() {
     let identifier = Math.floor(Math.random() * 999)
       .toString()
       .padStart(3, '0');
-    while (identifiers.includes(`LNUI-${identifier}`)) {
+    while (identifiers.includes(`CIR-${identifier}`)) {
       identifier = Math.floor(Math.random() * 999)
         .toString()
         .padStart(3, '0');
@@ -92,7 +92,7 @@ export function CreateNewIssue() {
 
     return {
       id: uuidv4(),
-      identifier: `LNUI-${identifier}`,
+      identifier: `CIR-${identifier}`,
       title: '',
       description: '',
       status: initialStatus,

--- a/components/layout/sidebar/help-button.tsx
+++ b/components/layout/sidebar/help-button.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import * as React from 'react';
-import { ExternalLink, HelpCircle, Keyboard, Search } from 'lucide-react';
+import { HelpCircle, Keyboard, Search } from 'lucide-react';
 
 import {
   DropdownMenu,
@@ -13,8 +13,6 @@ import {
 } from '~/components/ui/dropdown-menu';
 import { Button } from '~/components/ui/button';
 import { Input } from '~/components/ui/input';
-import Link from 'next/link';
-import { Box, Linkedin, Twitter, MessageCircle } from 'lucide-react';
 
 export function HelpButton() {
   return (
@@ -41,78 +39,6 @@ export function HelpButton() {
           <Keyboard className="mr-2 h-4 w-4" />
           <span>キーボードショートカット</span>
           <span className="ml-auto text-xs text-muted-foreground">⌘/</span>
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuLabel>フォローする</DropdownMenuLabel>
-        <DropdownMenuItem asChild>
-          <Link href="https://x.com/ln_dev7" target="_blank">
-            <Twitter className="mr-2 h-4 w-4" />
-            <span>X - Twitter</span>
-            <ExternalLink className="ml-auto h-3 w-3 text-muted-foreground" />
-          </Link>
-        </DropdownMenuItem>
-        <DropdownMenuItem asChild>
-          <Link href="https://threads.net/@ln_dev7" target="_blank">
-            <MessageCircle className="mr-2 h-4 w-4" />
-            <span>Threads</span>
-            <ExternalLink className="ml-auto h-3 w-3 text-muted-foreground" />
-          </Link>
-        </DropdownMenuItem>
-        <DropdownMenuItem asChild>
-          <Link href="https://linkedin.com/in/lndev" target="_blank">
-            <Linkedin className="mr-2 h-4 w-4" />
-            <span>LinkedIn</span>
-            <ExternalLink className="ml-auto h-3 w-3 text-muted-foreground" />
-          </Link>
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem asChild>
-          <Link
-            href="https://store.lndev.me/buy/f15f780c-8fbe-40e2-83e8-db1eb421abf4"
-            target="_blank"
-          >
-            <Box className="mr-2 h-4 w-4" />
-            <span>プロジェクトを支援</span>
-          </Link>
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuLabel>新着情報</DropdownMenuLabel>
-        <DropdownMenuItem asChild>
-          <Link
-            href="https://ui.lndev.me"
-            target="_blank"
-            className="flex items-center"
-          >
-            <div className="mr-2 flex h-4 w-4 items-center justify-center">
-              <div className="h-1.5 w-1.5 rounded-full bg-blue-500" />
-            </div>
-            <span>lndev-uiを起動</span>
-          </Link>
-        </DropdownMenuItem>
-        <DropdownMenuItem asChild>
-          <Link
-            href="https://lndev.me"
-            target="_blank"
-            className="flex items-center"
-          >
-            <div className="mr-2 flex h-4 w-4 items-center justify-center">
-              <div className="h-1.5 w-1.5 rounded-full bg-blue-500" />
-            </div>
-            <span>新しいポートフォリオ</span>
-          </Link>
-        </DropdownMenuItem>
-        <DropdownMenuItem asChild>
-          <Link
-            href="https://github.com/ln-dev7/circle"
-            target="_blank"
-            className="flex items-center"
-          >
-            <div className="mr-2 flex h-4 w-4 items-center justify-center">
-              <div className="h-1.5 w-1.5 rounded-full bg-transparent" />
-            </div>
-            <span>GitHub</span>
-            <ExternalLink className="ml-2 h-3 w-3 text-muted-foreground" />
-          </Link>
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/components/layout/sidebar/nav-teams.tsx
+++ b/components/layout/sidebar/nav-teams.tsx
@@ -104,7 +104,7 @@ export function NavTeams({ items }: { items: Team[] }) {
                   <SidebarMenuSub>
                     <SidebarMenuSubItem>
                       <SidebarMenuSubButton asChild>
-                        <Link href={`/lndev-ui/team/${item.id}/all`}>
+                        <Link href={`/circle/team/${item.id}/all`}>
                           <CopyMinus size={14} />
                           <span>課題</span>
                         </Link>
@@ -112,7 +112,7 @@ export function NavTeams({ items }: { items: Team[] }) {
                     </SidebarMenuSubItem>
                     <SidebarMenuSubItem>
                       <SidebarMenuSubButton asChild>
-                        <Link href={`/lndev-ui/team/${item.id}/all`}>
+                        <Link href={`/circle/team/${item.id}/all`}>
                           <ChartPie size={14} />
                           <span>サイクル</span>
                         </Link>
@@ -120,7 +120,7 @@ export function NavTeams({ items }: { items: Team[] }) {
                     </SidebarMenuSubItem>
                     <SidebarMenuSubItem>
                       <SidebarMenuSubButton asChild>
-                        <Link href="/lndev-ui/projects">
+                        <Link href="/circle/projects">
                           <Box size={14} />
                           <span>プロジェクト</span>
                         </Link>

--- a/components/layout/sidebar/org-switcher.tsx
+++ b/components/layout/sidebar/org-switcher.tsx
@@ -8,7 +8,6 @@ import {
   DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuItem,
-  DropdownMenuLabel,
   DropdownMenuPortal,
   DropdownMenuSeparator,
   DropdownMenuShortcut,
@@ -37,10 +36,10 @@ export function OrgSwitcher() {
                 className="h-8 p-1 data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
               >
                 <div className="flex aspect-square size-6 items-center justify-center rounded bg-orange-500 text-sidebar-primary-foreground">
-                  LN
+                  C
                 </div>
                 <div className="grid flex-1 text-left text-sm leading-tight">
-                  <span className="truncate font-semibold">lndev-ui</span>
+                  <span className="truncate font-semibold">circle</span>
                 </div>
                 <ChevronsUpDown className="ml-auto" />
               </SidebarMenuButton>
@@ -76,13 +75,11 @@ export function OrgSwitcher() {
               </DropdownMenuSubTrigger>
               <DropdownMenuPortal>
                 <DropdownMenuSubContent>
-                  <DropdownMenuLabel>leonelngoya@gmail.com</DropdownMenuLabel>
-                  <DropdownMenuSeparator />
                   <DropdownMenuItem>
                     <div className="flex aspect-square size-6 items-center justify-center rounded bg-orange-500 text-sidebar-primary-foreground">
-                      LN
+                      C
                     </div>
-                    lndev-ui
+                    circle
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem>

--- a/mock-data/cycles.ts
+++ b/mock-data/cycles.ts
@@ -31,7 +31,7 @@ export const cycles: Cycle[] = [
     id: '44',
     number: 44,
     name: 'スプリント 44 - コア機能強化',
-    teamId: 'circle-core',
+    teamId: 'CORE',
     startDate: '2025-03-10',
     endDate: '2025-03-24',
     progress: 0,

--- a/mock-data/cycles.ts
+++ b/mock-data/cycles.ts
@@ -31,7 +31,7 @@ export const cycles: Cycle[] = [
     id: '44',
     number: 44,
     name: 'スプリント 44 - コア機能強化',
-    teamId: 'lndev-core',
+    teamId: 'circle-core',
     startDate: '2025-03-10',
     endDate: '2025-03-24',
     progress: 0,

--- a/mock-data/issues.ts
+++ b/mock-data/issues.ts
@@ -78,7 +78,7 @@ generateIssuesRanks();
 export const issues: Issue[] = [
   {
     id: '1',
-    identifier: 'LNUI-101',
+    identifier: 'CIR-101',
     title: 'アクセシビリティ準拠のためにButtonコンポーネントをリファクタリング',
     description: '',
     status: getStatusByIndex(5),
@@ -92,7 +92,7 @@ export const issues: Issue[] = [
   },
   {
     id: '2',
-    identifier: 'LNUI-204',
+    identifier: 'CIR-204',
     title: 'よりスムーズなUI遷移のためにアニメーションを最適化',
     description: '',
     status: getStatusByIndex(2),
@@ -106,7 +106,7 @@ export const issues: Issue[] = [
   },
   {
     id: '3',
-    identifier: 'LNUI-309',
+    identifier: 'CIR-309',
     title: 'システム設定連携のダークモード切り替え機能を実装',
     description: '',
     status: getStatusByIndex(3),
@@ -120,7 +120,7 @@ export const issues: Issue[] = [
   },
   {
     id: '4',
-    identifier: 'LNUI-415',
+    identifier: 'CIR-415',
     title: 'フォーカストラップ機能を持つ新しいモーダルシステムを設計',
     description: '',
     status: getStatusByIndex(1),
@@ -134,7 +134,7 @@ export const issues: Issue[] = [
   },
   {
     id: '5',
-    identifier: 'LNUI-501',
+    identifier: 'CIR-501',
     title: 'ナビゲーションバーのレスポンシブ性を向上',
     description: '',
     status: getStatusByIndex(1),
@@ -149,7 +149,7 @@ export const issues: Issue[] = [
   },
   {
     id: '6',
-    identifier: 'LNUI-502',
+    identifier: 'CIR-502',
     title: 'フッターの読み込み時間を最適化',
     description: '',
     status: getStatusByIndex(2),
@@ -163,7 +163,7 @@ export const issues: Issue[] = [
   },
   {
     id: '7',
-    identifier: 'LNUI-503',
+    identifier: 'CIR-503',
     title: 'アクセシビリティ向上のためにサイドバーをリファクタリング',
     description: '',
     status: getStatusByIndex(3),
@@ -177,7 +177,7 @@ export const issues: Issue[] = [
   },
   {
     id: '8',
-    identifier: 'LNUI-504',
+    identifier: 'CIR-504',
     title: '新しいカードコンポーネントデザインを実装',
     description: '',
     status: getStatusByIndex(4),
@@ -191,7 +191,7 @@ export const issues: Issue[] = [
   },
   {
     id: '9',
-    identifier: 'LNUI-505',
+    identifier: 'CIR-505',
     title: 'ツールチップのインタラクティブ性を改善',
     description: '',
     status: getStatusByIndex(1),
@@ -205,7 +205,7 @@ export const issues: Issue[] = [
   },
   {
     id: '10',
-    identifier: 'LNUI-506',
+    identifier: 'CIR-506',
     title: 'モバイルデバイス向けにドロップダウンを再設計',
     description: '',
     status: getStatusByIndex(2),
@@ -219,7 +219,7 @@ export const issues: Issue[] = [
   },
   {
     id: '11',
-    identifier: 'LNUI-507',
+    identifier: 'CIR-507',
     title: 'フォームのバリデーション問題を修正',
     description: '',
     status: getStatusByIndex(3),
@@ -233,7 +233,7 @@ export const issues: Issue[] = [
   },
   {
     id: '12',
-    identifier: 'LNUI-508',
+    identifier: 'CIR-508',
     title: 'モーダルアニメーションを更新',
     description: '',
     status: getStatusByIndex(0),
@@ -247,7 +247,7 @@ export const issues: Issue[] = [
   },
   {
     id: '13',
-    identifier: 'LNUI-509',
+    identifier: 'CIR-509',
     title: 'ボタンの状態とインタラクションを刷新',
     description: '',
     status: getStatusByIndex(5),
@@ -261,7 +261,7 @@ export const issues: Issue[] = [
   },
   {
     id: '14',
-    identifier: 'LNUI-510',
+    identifier: 'CIR-510',
     title: '入力コンポーネントのスタイリングを合理化',
     description: '',
     status: getStatusByIndex(2),
@@ -275,7 +275,7 @@ export const issues: Issue[] = [
   },
   {
     id: '15',
-    identifier: 'LNUI-511',
+    identifier: 'CIR-511',
     title: '新しいセレクトコンポーネントの動作を統合',
     description: '',
     status: getStatusByIndex(3),
@@ -289,7 +289,7 @@ export const issues: Issue[] = [
   },
   {
     id: '16',
-    identifier: 'LNUI-512',
+    identifier: 'CIR-512',
     title: 'パンくずナビゲーションのユーザビリティを向上',
     description: '',
     status: getStatusByIndex(0),
@@ -303,7 +303,7 @@ export const issues: Issue[] = [
   },
   {
     id: '17',
-    identifier: 'LNUI-513',
+    identifier: 'CIR-513',
     title: 'スムーズな遷移のためにアコーディオンをリファクタリング',
     description: '',
     status: getStatusByIndex(1),
@@ -317,7 +317,7 @@ export const issues: Issue[] = [
   },
   {
     id: '18',
-    identifier: 'LNUI-514',
+    identifier: 'CIR-514',
     title: '遅延読み込み機能付きカルーセルを実装',
     description: '',
     status: getStatusByIndex(2),
@@ -331,7 +331,7 @@ export const issues: Issue[] = [
   },
   {
     id: '19',
-    identifier: 'LNUI-515',
+    identifier: 'CIR-515',
     title: 'レスポンシブデザイン向けにグリッドレイアウトを最適化',
     description: '',
     status: getStatusByIndex(3),
@@ -345,7 +345,7 @@ export const issues: Issue[] = [
   },
   {
     id: '20',
-    identifier: 'LNUI-516',
+    identifier: 'CIR-516',
     title: '明瞭さ向上のためにタイポグラフィシステムを更新',
     description: '',
     status: getStatusByIndex(4),
@@ -359,7 +359,7 @@ export const issues: Issue[] = [
   },
   {
     id: '21',
-    identifier: 'LNUI-517',
+    identifier: 'CIR-517',
     title: 'カラースキームの一貫性を改善',
     description: '',
     status: getStatusByIndex(1),
@@ -373,7 +373,7 @@ export const issues: Issue[] = [
   },
   {
     id: '22',
-    identifier: 'LNUI-518',
+    identifier: 'CIR-518',
     title: 'より良いスケーラビリティのための新しいアイコンセットを設計',
     description: '',
     status: getStatusByIndex(2),
@@ -387,7 +387,7 @@ export const issues: Issue[] = [
   },
   {
     id: '23',
-    identifier: 'LNUI-519',
+    identifier: 'CIR-519',
     title: '通知システムのタイミングを修正',
     description: '',
     status: getStatusByIndex(3),
@@ -401,7 +401,7 @@ export const issues: Issue[] = [
   },
   {
     id: '24',
-    identifier: 'LNUI-520',
+    identifier: 'CIR-520',
     title: 'ローディングインジケーターのパフォーマンスを向上',
     description: '',
     status: getStatusByIndex(0),
@@ -415,7 +415,7 @@ export const issues: Issue[] = [
   },
   {
     id: '25',
-    identifier: 'LNUI-521',
+    identifier: 'CIR-521',
     title: 'プログレスバーのアニメーションをリファクタリング',
     description: '',
     status: getStatusByIndex(5),
@@ -429,7 +429,7 @@ export const issues: Issue[] = [
   },
   {
     id: '26',
-    identifier: 'LNUI-522',
+    identifier: 'CIR-522',
     title: 'テーブルコンポーネントのソート機能を最適化',
     description: '',
     status: getStatusByIndex(2),
@@ -443,7 +443,7 @@ export const issues: Issue[] = [
   },
   {
     id: '27',
-    identifier: 'LNUI-523',
+    identifier: 'CIR-523',
     title: 'ページネーションロジックを改善',
     description: '',
     status: getStatusByIndex(3),
@@ -457,7 +457,7 @@ export const issues: Issue[] = [
   },
   {
     id: '28',
-    identifier: 'LNUI-524',
+    identifier: 'CIR-524',
     title: 'オートコンプリート機能付き検索バーを実装',
     description: '',
     status: getStatusByIndex(0),
@@ -471,7 +471,7 @@ export const issues: Issue[] = [
   },
   {
     id: '29',
-    identifier: 'LNUI-525',
+    identifier: 'CIR-525',
     title: '重要な通知のためのアラートシステムを更新',
     description: '',
     status: getStatusByIndex(1),
@@ -485,7 +485,7 @@ export const issues: Issue[] = [
   },
   {
     id: '30',
-    identifier: 'LNUI-526',
+    identifier: 'CIR-526',
     title: 'ユーザビリティ向上のためにオーバーレイを改良',
     description: '',
     status: getStatusByIndex(2),

--- a/mock-data/projects.ts
+++ b/mock-data/projects.ts
@@ -33,7 +33,7 @@ export interface Project {
 export const projects: Project[] = [
   {
     id: '1',
-    name: 'LNDev UI - コアコンポーネント',
+    name: 'Circle UI - コアコンポーネント',
     status: getStatusByIndex(0),
     icon: Cuboid,
     percentComplete: 80,
@@ -41,7 +41,7 @@ export const projects: Project[] = [
   },
   {
     id: '2',
-    name: 'LNDev UI - テーマ設定',
+    name: 'Circle UI - テーマ設定',
     status: getStatusByIndex(1),
     icon: Blocks,
     percentComplete: 50,
@@ -49,7 +49,7 @@ export const projects: Project[] = [
   },
   {
     id: '3',
-    name: 'LNDev UI - モーダル',
+    name: 'Circle UI - モーダル',
     status: getStatusByIndex(2),
     icon: Vault,
     percentComplete: 0,
@@ -57,7 +57,7 @@ export const projects: Project[] = [
   },
   {
     id: '4',
-    name: 'LNDev UI - ナビゲーション',
+    name: 'Circle UI - ナビゲーション',
     status: getStatusByIndex(3),
     icon: BrickWall,
     percentComplete: 0,
@@ -65,7 +65,7 @@ export const projects: Project[] = [
   },
   {
     id: '5',
-    name: 'LNDev UI - レイアウト',
+    name: 'Circle UI - レイアウト',
     status: getStatusByIndex(4),
     icon: Wallpaper,
     percentComplete: 0,
@@ -73,7 +73,7 @@ export const projects: Project[] = [
   },
   {
     id: '6',
-    name: 'LNDev UI - サイドバー',
+    name: 'Circle UI - サイドバー',
     status: getStatusByIndex(5),
     icon: TrafficCone,
     percentComplete: 0,
@@ -81,7 +81,7 @@ export const projects: Project[] = [
   },
   {
     id: '7',
-    name: 'LNDev UI - カード',
+    name: 'Circle UI - カード',
     status: getStatusByIndex(1),
     icon: Grid2X2,
     percentComplete: 0,
@@ -89,7 +89,7 @@ export const projects: Project[] = [
   },
   {
     id: '8',
-    name: 'LNDev UI - ツールチップ',
+    name: 'Circle UI - ツールチップ',
     status: getStatusByIndex(2),
     icon: Bomb,
     percentComplete: 0,
@@ -97,7 +97,7 @@ export const projects: Project[] = [
   },
   {
     id: '9',
-    name: 'LNDev UI - ドロップダウン',
+    name: 'Circle UI - ドロップダウン',
     status: getStatusByIndex(3),
     icon: Shapes,
     percentComplete: 50,

--- a/mock-data/teams.ts
+++ b/mock-data/teams.ts
@@ -18,7 +18,7 @@ export interface Team {
 export const teams: Team[] = [
   {
     id: 'CORE',
-    name: 'LNDevコアチーム',
+    name: 'コアチーム',
     icon: '🛠️',
     joined: true,
     color: '#FF0000',

--- a/mock-data/users.ts
+++ b/mock-data/users.ts
@@ -20,10 +20,10 @@ export const statusUserColors = {
 
 export const users: User[] = [
   {
-    id: 'ln',
-    name: 'leonel.ngoya',
-    avatarUrl: avatarUrl('ln'),
-    email: 'leonelngoya@gmail.com',
+    id: 'liam',
+    name: 'liam.foster',
+    avatarUrl: avatarUrl('liamfoster'),
+    email: 'liamfoster@gmail.com',
     status: 'オンライン',
     role: '管理者',
     joinedDate: '2022-01-01',


### PR DESCRIPTION
原作者の個人アカウント (lndev / ln-dev7 / leonel.ngoya) をアプリ全体から完全に排除する。

- 外部リンク削除: ヘルプメニューとサイドバーフッターから SNS (X/Threads/LinkedIn)、
  ポートフォリオ (lndev.me / ui.lndev.me)、store、GitHub (ln-dev7/circle) のリンクを除去
- 表示ID変更: org-switcher のワークスペース名/イニシャルを circle/C に変更し、
  ハードコードされた leonelngoya@gmail.com ラベルを削除
- モックデータ匿名化: ln/leonel.ngoya ユーザーを中立な架空ユーザーへ置換、
  プロジェクト接頭辞 LNDev UI → Circle UI、Issue識別子 LNUI- → CIR-、
  チーム名・cycle teamId の lndev 由来名を改名
- ルートスラッグ /lndev-ui → /circle に統一

未使用となったインポート/stateも整理。saedgewell (利用者自身のアカウント) は変更対象外。

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CSBLXS3ngdBUVazRjKXJ6L