### PR TITLE
feat(issues): persist issues to D1 via CRUD Server Actions (#20)

### DIFF
--- a/actions/issues.ts
+++ b/actions/issues.ts
@@ -1,10 +1,367 @@
 'use server';
 
-import { and, desc, eq, inArray } from 'drizzle-orm';
+import { and, desc, eq, inArray, like, type SQL } from 'drizzle-orm';
 
-import { getCurrentUserTeamIds } from '~/lib/auth-server';
-import { getDb } from '~/lib/db';
-import { issues, priorities, statuses, teamProjects } from '~/lib/db/schema';
+import { getCurrentUserTeamIds, requireUser } from '~/lib/auth-server';
+import { getDb, type Db } from '~/lib/db';
+import {
+  issueAssignees,
+  issueLabels,
+  issues,
+  labels,
+  priorities,
+  projects,
+  statuses,
+  teamProjects,
+  teams,
+  user as userTable,
+} from '~/lib/db/schema';
+import type { User, UserStatus } from '~/types/users';
+import LexRank from '~/utils/lexRank';
+
+// ---------------------------------------------------------------------------
+// Serializable DTOs returned to client components.
+//
+// Server Actions can only return serializable values, so icons are kept as
+// strings (the UI converts them with `getIconFromString`). These objects are
+// structurally compatible with the `Issue` type once cast on the client.
+// ---------------------------------------------------------------------------
+
+export interface IssueStatusDTO {
+  id: string;
+  name: string;
+  color: string;
+  icon: string;
+}
+
+export interface IssuePriorityDTO {
+  id: string;
+  name: string;
+  icon: string;
+}
+
+export interface IssueProjectDTO {
+  id: string;
+  name: string;
+  icon: string;
+  percentComplete: number | null;
+}
+
+export interface IssueDTO {
+  id: string;
+  identifier: string;
+  title: string;
+  description: string;
+  status: IssueStatusDTO;
+  priority: IssuePriorityDTO;
+  assignees: User | null;
+  labels: Array<{ id: string; name: string; color: string }>;
+  createdAt: string;
+  cycleId: string;
+  rank: string;
+  project?: IssueProjectDTO;
+}
+
+const DEFAULT_STATUS: IssueStatusDTO = {
+  id: 'not-started',
+  name: '未着手',
+  color: '#CBD5E1',
+  icon: 'circle',
+};
+
+const DEFAULT_PRIORITY: IssuePriorityDTO = {
+  id: 'no-priority',
+  name: '優先度なし',
+  icon: 'circle',
+};
+
+// ---------------------------------------------------------------------------
+// Authorization helpers (D1 has no RLS, so scope everything by team membership)
+// ---------------------------------------------------------------------------
+
+/**
+ * Slugs of the teams the current user belongs to. Issue identifiers are
+ * prefixed with the team slug (e.g. `CORE-12`), so these slugs are used both to
+ * scope which issues a user can see/mutate and to mint new identifiers.
+ */
+async function getCurrentUserTeamSlugs(): Promise<string[]> {
+  const teamIds = await getCurrentUserTeamIds();
+  if (teamIds.length === 0) {
+    return [];
+  }
+
+  const db = getDb();
+  const rows = await db
+    .select({ slug: teams.slug })
+    .from(teams)
+    .where(inArray(teams.id, teamIds));
+
+  return rows.map((row) => row.slug);
+}
+
+function teamSlugFromIdentifier(identifier: string): string {
+  const dash = identifier.indexOf('-');
+  return dash === -1 ? identifier : identifier.slice(0, dash);
+}
+
+/**
+ * Ensure the current user may read/mutate the given issue (its identifier
+ * prefix must belong to one of the user's teams). Returns the issue's
+ * identifier on success and throws otherwise.
+ */
+async function assertIssueAccess(db: Db, issueId: string): Promise<string> {
+  const [row] = await db
+    .select({ identifier: issues.identifier })
+    .from(issues)
+    .where(eq(issues.id, issueId))
+    .limit(1);
+
+  if (!row) {
+    throw new Error('課題が見つかりません');
+  }
+
+  const slugs = await getCurrentUserTeamSlugs();
+  if (!slugs.includes(teamSlugFromIdentifier(row.identifier))) {
+    throw new Error('この課題を操作する権限がありません');
+  }
+
+  return row.identifier;
+}
+
+// ---------------------------------------------------------------------------
+// Slug → primary-key resolution for reference data
+// ---------------------------------------------------------------------------
+
+async function statusIdFromSlug(
+  db: Db,
+  slug: string | null | undefined
+): Promise<string | null> {
+  if (!slug) return null;
+  const [row] = await db
+    .select({ id: statuses.id })
+    .from(statuses)
+    .where(eq(statuses.slug, slug))
+    .limit(1);
+  return row?.id ?? null;
+}
+
+async function priorityIdFromSlug(
+  db: Db,
+  slug: string | null | undefined
+): Promise<string | null> {
+  if (!slug) return null;
+  const [row] = await db
+    .select({ id: priorities.id })
+    .from(priorities)
+    .where(eq(priorities.slug, slug))
+    .limit(1);
+  return row?.id ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Identifier / rank generation
+// ---------------------------------------------------------------------------
+
+async function nextIdentifier(db: Db, teamSlug: string): Promise<string> {
+  const rows = await db
+    .select({ identifier: issues.identifier })
+    .from(issues)
+    .where(like(issues.identifier, `${teamSlug}-%`));
+
+  let max = 0;
+  for (const row of rows) {
+    const suffix = row.identifier.slice(teamSlug.length + 1);
+    const n = Number.parseInt(suffix, 10);
+    if (Number.isFinite(n) && n > max) {
+      max = n;
+    }
+  }
+  return `${teamSlug}-${max + 1}`;
+}
+
+async function nextRank(db: Db, teamSlug: string): Promise<string> {
+  const rows = await db
+    .select({ rank: issues.rank })
+    .from(issues)
+    .where(like(issues.identifier, `${teamSlug}-%`));
+
+  let maxRank: string | null = null;
+  for (const row of rows) {
+    if (row.rank && (maxRank === null || row.rank > maxRank)) {
+      maxRank = row.rank;
+    }
+  }
+
+  if (!maxRank) {
+    return new LexRank('a3c').toString();
+  }
+
+  try {
+    return LexRank.from(maxRank).increment().toString();
+  } catch {
+    const parsed = LexRank.from(maxRank);
+    return new LexRank(`${parsed.value}1`, parsed.bucket).toString();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// DTO loading
+// ---------------------------------------------------------------------------
+
+/**
+ * Load full issue DTOs (with status / priority / project / assignee / labels)
+ * for the rows matching `where`. Uses batched lookups to avoid N+1 queries.
+ */
+async function loadIssueDTOs(db: Db, where: SQL): Promise<IssueDTO[]> {
+  const rows = await db
+    .select({
+      id: issues.id,
+      identifier: issues.identifier,
+      title: issues.title,
+      description: issues.description,
+      cycleId: issues.cycleId,
+      rank: issues.rank,
+      createdAt: issues.createdAt,
+      statusSlug: statuses.slug,
+      statusName: statuses.name,
+      statusColor: statuses.color,
+      statusIcon: statuses.icon,
+      prioritySlug: priorities.slug,
+      priorityName: priorities.name,
+      priorityIcon: priorities.icon,
+      projectId: projects.id,
+      projectName: projects.name,
+      projectIcon: projects.icon,
+      projectPercent: projects.percentComplete,
+    })
+    .from(issues)
+    .leftJoin(statuses, eq(issues.statusId, statuses.id))
+    .leftJoin(priorities, eq(issues.priorityId, priorities.id))
+    .leftJoin(projects, eq(issues.projectId, projects.id))
+    .where(where)
+    .orderBy(desc(issues.rank), desc(issues.createdAt));
+
+  if (rows.length === 0) {
+    return [];
+  }
+
+  const issueIds = rows.map((row) => row.id);
+
+  // Assignees (the UI models a single assignee per issue).
+  const assigneeRows = await db
+    .select({
+      issueId: issueAssignees.issueId,
+      id: userTable.id,
+      name: userTable.name,
+      email: userTable.email,
+      image: userTable.image,
+      role: userTable.role,
+      status: userTable.status,
+      createdAt: userTable.createdAt,
+    })
+    .from(issueAssignees)
+    .innerJoin(userTable, eq(issueAssignees.userId, userTable.id))
+    .where(inArray(issueAssignees.issueId, issueIds));
+
+  const assigneeByIssue = new Map<string, User>();
+  for (const row of assigneeRows) {
+    if (assigneeByIssue.has(row.issueId)) continue;
+    assigneeByIssue.set(row.issueId, {
+      id: row.id,
+      name: row.name,
+      email: row.email,
+      avatarUrl: row.image,
+      role: row.role ?? undefined,
+      status: (row.status as UserStatus | null) ?? undefined,
+      joinedDate: row.createdAt
+        ? new Date(row.createdAt).toISOString()
+        : undefined,
+    });
+  }
+
+  // Labels.
+  const labelRows = await db
+    .select({
+      issueId: issueLabels.issueId,
+      id: labels.id,
+      name: labels.name,
+      color: labels.color,
+    })
+    .from(issueLabels)
+    .innerJoin(labels, eq(issueLabels.labelId, labels.id))
+    .where(inArray(issueLabels.issueId, issueIds));
+
+  const labelsByIssue = new Map<
+    string,
+    Array<{ id: string; name: string; color: string }>
+  >();
+  for (const row of labelRows) {
+    const list = labelsByIssue.get(row.issueId) ?? [];
+    list.push({ id: row.id, name: row.name, color: row.color });
+    labelsByIssue.set(row.issueId, list);
+  }
+
+  return rows.map((row) => ({
+    id: row.id,
+    identifier: row.identifier,
+    title: row.title,
+    description: row.description ?? '',
+    status: row.statusSlug
+      ? {
+          id: row.statusSlug,
+          name: row.statusName ?? row.statusSlug,
+          color: row.statusColor ?? '#888888',
+          icon: row.statusIcon ?? 'circle',
+        }
+      : DEFAULT_STATUS,
+    priority: row.prioritySlug
+      ? {
+          id: row.prioritySlug,
+          name: row.priorityName ?? row.prioritySlug,
+          icon: row.priorityIcon ?? 'circle',
+        }
+      : DEFAULT_PRIORITY,
+    assignees: assigneeByIssue.get(row.id) ?? null,
+    labels: labelsByIssue.get(row.id) ?? [],
+    createdAt: row.createdAt ?? new Date().toISOString(),
+    cycleId: row.cycleId ?? '',
+    rank: row.rank ?? '',
+    project: row.projectId
+      ? {
+          id: row.projectId,
+          name: row.projectName ?? '',
+          icon: row.projectIcon ?? 'folder',
+          percentComplete: row.projectPercent ?? null,
+        }
+      : undefined,
+  }));
+}
+
+async function loadIssueDTOById(
+  db: Db,
+  issueId: string
+): Promise<IssueDTO | null> {
+  const [dto] = await loadIssueDTOs(db, eq(issues.id, issueId));
+  return dto ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Reads
+// ---------------------------------------------------------------------------
+
+/**
+ * All issues for a team (by identifier prefix), scoped to the current user's
+ * membership. Used to hydrate the board's initial state from D1.
+ */
+export async function getIssuesForTeam(teamSlug: string): Promise<IssueDTO[]> {
+  const slugs = await getCurrentUserTeamSlugs();
+  if (!slugs.includes(teamSlug)) {
+    return [];
+  }
+
+  const db = getDb();
+  return loadIssueDTOs(db, like(issues.identifier, `${teamSlug}-%`));
+}
 
 export async function getIssuesByProjectId(projectId: string) {
   const db = getDb();
@@ -80,4 +437,209 @@ export async function getIssuesByProjectId(projectId: string) {
         }
       : null,
   }));
+}
+
+// ---------------------------------------------------------------------------
+// Create
+// ---------------------------------------------------------------------------
+
+export interface CreateIssueInput {
+  title: string;
+  description?: string;
+  /** Status slug (as exposed by `getStatuses`). */
+  statusId?: string | null;
+  /** Priority slug (as exposed by `getPriorities`). */
+  priorityId?: string | null;
+  /** Assignee user id, or null for unassigned. */
+  assigneeId?: string | null;
+  /** Label ids. */
+  labelIds?: string[];
+  /** Project id, or null. */
+  projectId?: string | null;
+  /** Team slug to mint the identifier under. Falls back to the user's first team. */
+  teamId?: string | null;
+}
+
+export async function createIssue(input: CreateIssueInput): Promise<IssueDTO> {
+  const sessionUser = await requireUser();
+
+  const title = input.title.trim();
+  if (!title) {
+    throw new Error('タイトルは必須です');
+  }
+
+  const slugs = await getCurrentUserTeamSlugs();
+  if (slugs.length === 0) {
+    throw new Error('所属チームがありません');
+  }
+
+  const teamSlug =
+    input.teamId && slugs.includes(input.teamId) ? input.teamId : slugs[0];
+  if (!teamSlug) {
+    throw new Error('所属チームがありません');
+  }
+
+  const db = getDb();
+
+  const [statusId, priorityId, identifier, rank] = await Promise.all([
+    statusIdFromSlug(db, input.statusId),
+    priorityIdFromSlug(db, input.priorityId),
+    nextIdentifier(db, teamSlug),
+    nextRank(db, teamSlug),
+  ]);
+
+  const id = crypto.randomUUID();
+
+  await db.insert(issues).values({
+    id,
+    identifier,
+    title,
+    description: input.description ?? null,
+    statusId,
+    priorityId,
+    projectId: input.projectId ?? null,
+    rank,
+    createdBy: sessionUser.id,
+  });
+
+  if (input.assigneeId) {
+    await db.insert(issueAssignees).values({
+      issueId: id,
+      userId: input.assigneeId,
+    });
+  }
+
+  if (input.labelIds && input.labelIds.length > 0) {
+    await db
+      .insert(issueLabels)
+      .values(
+        input.labelIds.map((labelId) => ({ issueId: id, labelId }))
+      );
+  }
+
+  const dto = await loadIssueDTOById(db, id);
+  if (!dto) {
+    throw new Error('課題の作成に失敗しました');
+  }
+  return dto;
+}
+
+// ---------------------------------------------------------------------------
+// Update / delete
+// ---------------------------------------------------------------------------
+
+export async function updateIssue(
+  issueId: string,
+  input: { title?: string; description?: string }
+): Promise<void> {
+  const db = getDb();
+  await assertIssueAccess(db, issueId);
+
+  const patch: Record<string, unknown> = { updatedAt: nowIso() };
+  if (input.title !== undefined) {
+    const title = input.title.trim();
+    if (!title) {
+      throw new Error('タイトルは必須です');
+    }
+    patch.title = title;
+  }
+  if (input.description !== undefined) {
+    patch.description = input.description;
+  }
+
+  await db.update(issues).set(patch).where(eq(issues.id, issueId));
+}
+
+export async function deleteIssue(issueId: string): Promise<void> {
+  const db = getDb();
+  await assertIssueAccess(db, issueId);
+  // issue_assignees / issue_labels / issue_relations cascade on delete.
+  await db.delete(issues).where(eq(issues.id, issueId));
+}
+
+export async function updateIssueStatus(
+  issueId: string,
+  statusSlug: string
+): Promise<void> {
+  const db = getDb();
+  await assertIssueAccess(db, issueId);
+
+  const statusId = await statusIdFromSlug(db, statusSlug);
+  await db
+    .update(issues)
+    .set({ statusId, updatedAt: nowIso() })
+    .where(eq(issues.id, issueId));
+}
+
+export async function updateIssuePriority(
+  issueId: string,
+  prioritySlug: string
+): Promise<void> {
+  const db = getDb();
+  await assertIssueAccess(db, issueId);
+
+  const priorityId = await priorityIdFromSlug(db, prioritySlug);
+  await db
+    .update(issues)
+    .set({ priorityId, updatedAt: nowIso() })
+    .where(eq(issues.id, issueId));
+}
+
+export async function updateIssueRank(
+  issueId: string,
+  rank: string
+): Promise<void> {
+  const db = getDb();
+  await assertIssueAccess(db, issueId);
+  await db
+    .update(issues)
+    .set({ rank, updatedAt: nowIso() })
+    .where(eq(issues.id, issueId));
+}
+
+// ---------------------------------------------------------------------------
+// Assignee / labels (join tables)
+// ---------------------------------------------------------------------------
+
+export async function updateIssueAssignee(
+  issueId: string,
+  userId: string | null
+): Promise<void> {
+  const db = getDb();
+  await assertIssueAccess(db, issueId);
+
+  // Single-assignee model: clear then set.
+  await db.delete(issueAssignees).where(eq(issueAssignees.issueId, issueId));
+  if (userId) {
+    await db.insert(issueAssignees).values({ issueId, userId });
+  }
+}
+
+export async function addIssueLabel(
+  issueId: string,
+  labelId: string
+): Promise<void> {
+  const db = getDb();
+  await assertIssueAccess(db, issueId);
+  await db
+    .insert(issueLabels)
+    .values({ issueId, labelId })
+    .onConflictDoNothing();
+}
+
+export async function removeIssueLabel(
+  issueId: string,
+  labelId: string
+): Promise<void> {
+  const db = getDb();
+  await assertIssueAccess(db, issueId);
+  await db
+    .delete(issueLabels)
+    .where(
+      and(eq(issueLabels.issueId, issueId), eq(issueLabels.labelId, labelId))
+    );
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
 }

--- a/actions/issues.ts
+++ b/actions/issues.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { and, desc, eq, inArray, like, type SQL } from 'drizzle-orm';
+import type { BatchItem } from 'drizzle-orm/batch';
 
 import { getCurrentUserTeamIds, requireUser } from '~/lib/auth-server';
 import { getDb, type Db } from '~/lib/db';
@@ -62,11 +63,14 @@ export interface IssueDTO {
   project?: IssueProjectDTO;
 }
 
+// Fallback shown when an issue has no status. Uses a seeded slug (`to-do`) so
+// status-less issues still group into an existing board column rather than an
+// unknown one.
 const DEFAULT_STATUS: IssueStatusDTO = {
-  id: 'not-started',
+  id: 'to-do',
   name: '未着手',
-  color: '#CBD5E1',
-  icon: 'circle',
+  color: '#f97316',
+  icon: 'to-do',
 };
 
 const DEFAULT_PRIORITY: IssuePriorityDTO = {
@@ -126,6 +130,30 @@ async function assertIssueAccess(db: Db, issueId: string): Promise<string> {
   }
 
   return row.identifier;
+}
+
+/** Whether a project is linked to the given team (via `team_projects`). */
+async function isProjectInTeam(
+  db: Db,
+  projectId: string,
+  teamSlug: string
+): Promise<boolean> {
+  const [row] = await db
+    .select({ id: teamProjects.id })
+    .from(teamProjects)
+    .innerJoin(teams, eq(teamProjects.teamId, teams.id))
+    .where(
+      and(eq(teams.slug, teamSlug), eq(teamProjects.projectId, projectId))
+    )
+    .limit(1);
+  return Boolean(row);
+}
+
+type BatchWrite = BatchItem<'sqlite'>;
+
+function isUniqueViolation(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes('UNIQUE constraint failed');
 }
 
 // ---------------------------------------------------------------------------
@@ -481,40 +509,70 @@ export async function createIssue(input: CreateIssueInput): Promise<IssueDTO> {
 
   const db = getDb();
 
-  const [statusId, priorityId, identifier, rank] = await Promise.all([
+  const [statusId, priorityId] = await Promise.all([
     statusIdFromSlug(db, input.statusId),
     priorityIdFromSlug(db, input.priorityId),
-    nextIdentifier(db, teamSlug),
-    nextRank(db, teamSlug),
   ]);
+
+  // Only attach a project that is actually linked to the target team, so a
+  // stale/forged payload cannot cross-link an issue to another team's project
+  // (D1 has no RLS).
+  let projectId: string | null = null;
+  if (input.projectId && (await isProjectInTeam(db, input.projectId, teamSlug))) {
+    projectId = input.projectId;
+  }
 
   const id = crypto.randomUUID();
 
-  await db.insert(issues).values({
-    id,
-    identifier,
-    title,
-    description: input.description ?? null,
-    statusId,
-    priorityId,
-    projectId: input.projectId ?? null,
-    rank,
-    createdBy: sessionUser.id,
-  });
+  // Allocate the identifier and write the issue + its join rows atomically.
+  // `nextIdentifier` is read-then-write, so a concurrent create can race for the
+  // same value; retry on the resulting UNIQUE violation with a fresh number.
+  const MAX_ATTEMPTS = 5;
+  for (let attempt = 1; ; attempt++) {
+    const [identifier, rank] = await Promise.all([
+      nextIdentifier(db, teamSlug),
+      nextRank(db, teamSlug),
+    ]);
 
-  if (input.assigneeId) {
-    await db.insert(issueAssignees).values({
-      issueId: id,
-      userId: input.assigneeId,
-    });
-  }
+    const writes: BatchWrite[] = [
+      db.insert(issues).values({
+        id,
+        identifier,
+        title,
+        description: input.description ?? null,
+        statusId,
+        priorityId,
+        projectId,
+        rank,
+        createdBy: sessionUser.id,
+      }),
+    ];
 
-  if (input.labelIds && input.labelIds.length > 0) {
-    await db
-      .insert(issueLabels)
-      .values(
-        input.labelIds.map((labelId) => ({ issueId: id, labelId }))
+    if (input.assigneeId) {
+      writes.push(
+        db.insert(issueAssignees).values({ issueId: id, userId: input.assigneeId })
       );
+    }
+
+    if (input.labelIds && input.labelIds.length > 0) {
+      const uniqueLabelIds = [...new Set(input.labelIds)];
+      writes.push(
+        db
+          .insert(issueLabels)
+          .values(uniqueLabelIds.map((labelId) => ({ issueId: id, labelId })))
+          .onConflictDoNothing()
+      );
+    }
+
+    try {
+      await db.batch(writes as [BatchWrite, ...BatchWrite[]]);
+      break;
+    } catch (error) {
+      if (attempt < MAX_ATTEMPTS && isUniqueViolation(error)) {
+        continue;
+      }
+      throw error;
+    }
   }
 
   const dto = await loadIssueDTOById(db, id);

--- a/app/[orgId]/team/[teamId]/all/page.tsx
+++ b/app/[orgId]/team/[teamId]/all/page.tsx
@@ -1,5 +1,17 @@
 import AllIssues from '~/components/common/issues/all-issues';
+import { getIssuesForTeam } from '~/actions/issues';
+import type { Issue } from '~/types/issues';
 
-export default function AllIssuesPage() {
-  return <AllIssues />;
+export default async function AllIssuesPage({
+  params,
+}: {
+  params: Promise<{ orgId: string; teamId: string }>;
+}) {
+  const { teamId } = await params;
+
+  // Fetch the team's issues from D1 (scoped to the current user's membership)
+  // and hand them to the board for hydration, replacing the old mock data.
+  const initialIssues = (await getIssuesForTeam(teamId)) as unknown as Issue[];
+
+  return <AllIssues initialIssues={initialIssues} />;
 }

--- a/components/common/issues/all-issues.tsx
+++ b/components/common/issues/all-issues.tsx
@@ -1,16 +1,17 @@
 'use client';
 
-import { useAtomValue } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import { statusesAtom } from '~/store/status-atoms';
-import { issuesByStatusAtom } from '~/store/issues-store';
+import { issuesAtom, issuesByStatusAtom } from '~/store/issues-store';
 import { viewTypeAtom } from '~/store/view-store';
-import type { FC } from 'react';
+import { type FC, useEffect } from 'react';
 import { DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { GroupIssues } from './group-issues';
 import { SearchIssues } from './search-issues';
 import { CustomDragLayer } from './issue-grid';
 import { cn } from '~/lib/utils/cn';
+import type { Issue } from '~/types/issues';
 
 /**
  * 全課題表示コンポーネント
@@ -18,10 +19,23 @@ import { cn } from '~/lib/utils/cn';
  * 検索モードとグループ表示モード（リスト/ボード）を切り替えられます。
  * ドラッグ&ドロップ機能も統合されています。
  */
-export default function AllIssues() {
+export default function AllIssues({
+  initialIssues = [],
+}: {
+  initialIssues?: Issue[];
+}) {
   const viewType = useAtomValue(viewTypeAtom);
+  const setIssues = useSetAtom(issuesAtom);
   const isSearchOpen = false;
   const searchQuery = '';
+
+  // Hydrate the store with the team's issues fetched from D1 on the server.
+  // Runs whenever the route (and therefore the provided data) changes.
+  useEffect(() => {
+    setIssues(
+      [...initialIssues].sort((a, b) => (b.rank ?? '').localeCompare(a.rank ?? ''))
+    );
+  }, [initialIssues, setIssues]);
 
   const isSearching = isSearchOpen && searchQuery.trim() !== '';
   const isViewTypeGrid = viewType === 'grid';

--- a/components/layout/sidebar/create-new-issue/index.tsx
+++ b/components/layout/sidebar/create-new-issue/index.tsx
@@ -53,14 +53,14 @@ export function CreateNewIssue() {
   const statuses = useAtomValue(statusesAtom);
   const priorities = useAtomValue(prioritiesAtom);
 
-  // チームのスラッグはルート（/[orgId]/team/[teamId]/all）から取得する。
-  // identifier / rank はサーバー側で採番されるため、ここでは生成しない。
+  // Team slug comes from the route (/[orgId]/team/[teamId]/all). The identifier
+  // and rank are minted server-side, so they are not generated here.
   const params = useParams();
   const teamId =
     typeof params?.teamId === 'string' ? params.teamId : undefined;
 
-  // 新規課題のデフォルトデータ（フォームの初期値）を作成する関数。
-  // identifier と rank はサーバー側で確定するためプレースホルダーを置く。
+  // Build the default form data for a new issue. The identifier and rank are
+  // finalized on the server, so placeholders are used here.
   const createDefaultData = useCallback((): Issue => {
     const initialStatus: Status | undefined =
       defaultStatus || statuses.find((s) => s.id === 'to-do');
@@ -131,7 +131,8 @@ export function CreateNewIssue() {
     setIsSubmitting(true);
     let createdIssue: Issue;
     try {
-      // D1 に永続化（identifier / rank はサーバー側で採番）し、確定済みの課題を取得。
+      // Persist to D1 (identifier / rank minted server-side) and get the
+      // confirmed issue back.
       const dto = await createIssueAction({
         title: addIssueForm.title,
         description: addIssueForm.description,
@@ -144,7 +145,7 @@ export function CreateNewIssue() {
       });
       createdIssue = dto as unknown as Issue;
     } catch (error) {
-      console.error('課題の作成に失敗しました', error);
+      console.error('Failed to create issue', error);
       toast.error('課題の作成に失敗しました');
       setIsSubmitting(false);
       return;

--- a/components/layout/sidebar/create-new-issue/index.tsx
+++ b/components/layout/sidebar/create-new-issue/index.tsx
@@ -13,9 +13,11 @@ import { Switch } from '~/components/ui/switch';
 import { Label } from '~/components/ui/label';
 import { Edit } from 'lucide-react';
 import { useState, useEffect, useCallback } from 'react';
+import { useParams } from 'next/navigation';
 import type { Issue } from '~/types/issues';
 import { useAtomValue, useSetAtom } from 'jotai';
-import { issuesAtom, addIssueAtom } from '~/store/issues-store';
+import { addIssueAtom } from '~/store/issues-store';
+import { createIssue as createIssueAction } from '~/actions/issues';
 import { statusesAtom } from '~/store/status-atoms';
 import { prioritiesAtom } from '~/store/priority-atoms';
 import type { Status } from '~/types/status';
@@ -33,7 +35,6 @@ import { PrioritySelector } from '../priority-selector';
 import { AssigneeSelector } from './assignee-selector';
 import { ProjectSelector } from './project-selector';
 import { LabelSelector } from './label-selector';
-import { ranks } from '~/mock-data/issues';
 
 /**
  * 新規課題作成コンポーネント
@@ -49,33 +50,23 @@ export function CreateNewIssue() {
   const openModal = useSetAtom(openCreateIssueModalAtom);
   const closeModal = useSetAtom(closeCreateIssueModalAtom);
   const addIssue = useSetAtom(addIssueAtom);
-  const allIssues = useAtomValue(issuesAtom);
   const statuses = useAtomValue(statusesAtom);
   const priorities = useAtomValue(prioritiesAtom);
 
-  // ユニークな課題ID（identifier）を生成するヘルパー関数
-  const generateUniqueIdentifier = useCallback(() => {
-    const identifiers = allIssues.map((issue: Issue) => issue.identifier);
-    let identifier = Math.floor(Math.random() * 999)
-      .toString()
-      .padStart(3, '0');
-    while (identifiers.includes(`CIR-${identifier}`)) {
-      identifier = Math.floor(Math.random() * 999)
-        .toString()
-        .padStart(3, '0');
-    }
-    return identifier;
-  }, [allIssues]);
+  // チームのスラッグはルート（/[orgId]/team/[teamId]/all）から取得する。
+  // identifier / rank はサーバー側で採番されるため、ここでは生成しない。
+  const params = useParams();
+  const teamId =
+    typeof params?.teamId === 'string' ? params.teamId : undefined;
 
-  // 新規課題のデフォルトデータを作成する関数
+  // 新規課題のデフォルトデータ（フォームの初期値）を作成する関数。
+  // identifier と rank はサーバー側で確定するためプレースホルダーを置く。
   const createDefaultData = useCallback((): Issue => {
-    const identifier = generateUniqueIdentifier();
     const initialStatus: Status | undefined =
       defaultStatus || statuses.find((s) => s.id === 'to-do');
     const initialPriority: Priority | undefined = priorities.find(
       (p) => p.id === 'no-priority'
     );
-    const initialRank = ranks[ranks.length - 1];
 
     if (!initialStatus) {
       console.error('デフォルトステータス "to-do" が見つかりません！');
@@ -85,14 +76,10 @@ export function CreateNewIssue() {
       console.error('デフォルト優先度 "no-priority" が見つかりません！');
       throw new Error('デフォルト優先度の設定エラー。');
     }
-    if (initialRank === undefined) {
-      console.error('デフォルトランクが見つかりません！');
-      throw new Error('デフォルトランクの設定エラー。');
-    }
 
     return {
       id: uuidv4(),
-      identifier: `CIR-${identifier}`,
+      identifier: '',
       title: '',
       description: '',
       status: initialStatus,
@@ -103,9 +90,9 @@ export function CreateNewIssue() {
       cycleId: '',
       project: undefined,
       subissues: [],
-      rank: initialRank,
+      rank: '',
     };
-  }, [defaultStatus, generateUniqueIdentifier, statuses, priorities]);
+  }, [defaultStatus, statuses, priorities]);
 
   // Initialize form state with null
   const [addIssueForm, setAddIssueForm] = useState<Issue | null>(null);
@@ -128,8 +115,10 @@ export function CreateNewIssue() {
     // Add statuses and priorities to dependency array
   }, [isOpen, statuses, priorities, createDefaultData, closeModal]);
 
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
   // Function to create issue (add guard for null addIssueForm)
-  const createIssue = () => {
+  const createIssue = async () => {
     if (!addIssueForm) {
       toast.error('フォームが初期化されていません。');
       return;
@@ -138,8 +127,32 @@ export function CreateNewIssue() {
       toast.error('タイトルは必須です');
       return;
     }
+
+    setIsSubmitting(true);
+    let createdIssue: Issue;
+    try {
+      // D1 に永続化（identifier / rank はサーバー側で採番）し、確定済みの課題を取得。
+      const dto = await createIssueAction({
+        title: addIssueForm.title,
+        description: addIssueForm.description,
+        statusId: addIssueForm.status.id,
+        priorityId: addIssueForm.priority.id,
+        assigneeId: addIssueForm.assignees?.id ?? null,
+        labelIds: addIssueForm.labels.map((label) => label.id),
+        projectId: addIssueForm.project?.id ?? null,
+        teamId,
+      });
+      createdIssue = dto as unknown as Issue;
+    } catch (error) {
+      console.error('課題の作成に失敗しました', error);
+      toast.error('課題の作成に失敗しました');
+      setIsSubmitting(false);
+      return;
+    }
+    setIsSubmitting(false);
+
     toast.success('課題が作成されました');
-    addIssue(addIssueForm);
+    addIssue(createdIssue);
     if (!createMore) {
       closeModal();
     } else {
@@ -295,8 +308,9 @@ export function CreateNewIssue() {
             <Button
               size="sm"
               onClick={createIssue} // onClick handler already has null check
+              disabled={isSubmitting}
             >
-              課題を作成
+              {isSubmitting ? '作成中...' : '課題を作成'}
             </Button>
           </div>
         </DialogContent>

--- a/store/issues-store.ts
+++ b/store/issues-store.ts
@@ -18,13 +18,20 @@ import type { Status } from '../types/status';
 import type { User } from '../types/users';
 
 /**
- * Server Action を発火し、失敗時にユーザーへトーストで通知するヘルパー。
- * 楽観的更新（Jotai 側）はそのまま残し、リロード時にサーバーの確定状態へ収束する。
+ * Fire a Server Action for an already-applied optimistic update. On failure it
+ * notifies the user (toast, Japanese), logs in English, and rolls the
+ * optimistic change back so the UI matches the server state.
  */
-function persist(promise: Promise<unknown>, errorMessage: string): void {
+function persist(
+  promise: Promise<unknown>,
+  userMessage: string,
+  logMessage: string,
+  rollback: () => void
+): void {
   promise.catch((error) => {
-    console.error(errorMessage, error);
-    toast.error(errorMessage);
+    console.error(logMessage, error);
+    toast.error(userMessage);
+    rollback();
   });
 }
 
@@ -86,10 +93,15 @@ export const updateIssueAtom = atom(
  *              書き込み関数は削除する Issue の ID を受け取ります。
  */
 export const deleteIssueAtom = atom(null, (get, set, id: string) => {
-  const currentIssues = get(issuesAtom);
-  const updatedIssues = currentIssues.filter((issue) => issue.id !== id);
+  const previousIssues = get(issuesAtom);
+  const updatedIssues = previousIssues.filter((issue) => issue.id !== id);
   set(issuesAtom, updatedIssues);
-  persist(deleteIssueAction(id), '課題の削除に失敗しました');
+  persist(
+    deleteIssueAction(id),
+    '課題の削除に失敗しました',
+    'Failed to delete issue',
+    () => set(issuesAtom, previousIssues)
+  );
 });
 
 /**
@@ -104,13 +116,16 @@ export const updateIssueStatusAtom = atom(
     { issueId, newStatus }: { issueId: string; newStatus: Status }
   ) => {
     // 内部で updateIssueAtom を呼び出す
+    const previousIssues = get(issuesAtom);
     set(updateIssueAtom, {
       id: issueId,
       updatedIssueData: { status: newStatus },
     });
     persist(
       updateIssueStatusAction(issueId, newStatus.id),
-      'ステータスの更新に失敗しました'
+      'ステータスの更新に失敗しました',
+      'Failed to update issue status',
+      () => set(issuesAtom, previousIssues)
     );
   }
 );
@@ -126,13 +141,16 @@ export const updateIssuePriorityAtom = atom(
     set,
     { issueId, newPriority }: { issueId: string; newPriority: Priority }
   ) => {
+    const previousIssues = get(issuesAtom);
     set(updateIssueAtom, {
       id: issueId,
       updatedIssueData: { priority: newPriority },
     });
     persist(
       updateIssuePriorityAction(issueId, newPriority.id),
-      '優先度の更新に失敗しました'
+      '優先度の更新に失敗しました',
+      'Failed to update issue priority',
+      () => set(issuesAtom, previousIssues)
     );
   }
 );
@@ -148,13 +166,16 @@ export const updateIssueAssigneeAtom = atom(
     set,
     { issueId, newAssignee }: { issueId: string; newAssignee: User | null }
   ) => {
+    const previousIssues = get(issuesAtom);
     set(updateIssueAtom, {
       id: issueId,
       updatedIssueData: { assignees: newAssignee },
     });
     persist(
       updateIssueAssigneeAction(issueId, newAssignee?.id ?? null),
-      '担当者の更新に失敗しました'
+      '担当者の更新に失敗しました',
+      'Failed to update issue assignee',
+      () => set(issuesAtom, previousIssues)
     );
   }
 );
@@ -173,6 +194,7 @@ export const addIssueLabelAtom = atom(
     const issue = get(issueByIdAtom(issueId)); // Get the specific issue
     if (issue && !issue.labels.some((l) => l.id === label.id)) {
       // Avoid duplicates
+      const previousIssues = get(issuesAtom);
       const updatedLabels = [...issue.labels, label];
       set(updateIssueAtom, {
         id: issueId,
@@ -180,7 +202,9 @@ export const addIssueLabelAtom = atom(
       });
       persist(
         addIssueLabelAction(issueId, label.id),
-        'ラベルの追加に失敗しました'
+        'ラベルの追加に失敗しました',
+        'Failed to add issue label',
+        () => set(issuesAtom, previousIssues)
       );
     }
   }
@@ -195,6 +219,7 @@ export const removeIssueLabelAtom = atom(
   (get, set, { issueId, labelId }: { issueId: string; labelId: string }) => {
     const issue = get(issueByIdAtom(issueId));
     if (issue) {
+      const previousIssues = get(issuesAtom);
       const updatedLabels = issue.labels.filter(
         (label) => label.id !== labelId
       );
@@ -204,7 +229,9 @@ export const removeIssueLabelAtom = atom(
       });
       persist(
         removeIssueLabelAction(issueId, labelId),
-        'ラベルの削除に失敗しました'
+        'ラベルの削除に失敗しました',
+        'Failed to remove issue label',
+        () => set(issuesAtom, previousIssues)
       );
     }
   }

--- a/store/issues-store.ts
+++ b/store/issues-store.ts
@@ -1,6 +1,14 @@
 import { atom } from 'jotai';
 import { atomFamily } from 'jotai/utils'; // パラメータ付きatomのために追加
-import { issues as mockIssues } from '../mock-data/issues'; // Issue と groupIssuesByStatus を削除
+import { toast } from 'sonner';
+import {
+  addIssueLabel as addIssueLabelAction,
+  deleteIssue as deleteIssueAction,
+  removeIssueLabel as removeIssueLabelAction,
+  updateIssueAssignee as updateIssueAssigneeAction,
+  updateIssuePriority as updateIssuePriorityAction,
+  updateIssueStatus as updateIssueStatusAction,
+} from '~/actions/issues';
 import type { Issue } from '~/types/issues'; // Issue のインポート元を変更
 import { groupIssuesByStatus } from '~/utils/issue-utils'; // groupIssuesByStatus のインポート元を変更
 import type { LabelInterface } from '../types/labels';
@@ -9,15 +17,25 @@ import type { Project } from '../types/projects';
 import type { Status } from '../types/status';
 import type { User } from '../types/users';
 
+/**
+ * Server Action を発火し、失敗時にユーザーへトーストで通知するヘルパー。
+ * 楽観的更新（Jotai 側）はそのまま残し、リロード時にサーバーの確定状態へ収束する。
+ */
+function persist(promise: Promise<unknown>, errorMessage: string): void {
+  promise.catch((error) => {
+    console.error(errorMessage, error);
+    toast.error(errorMessage);
+  });
+}
+
 // --- Base Atoms ---
 
 /**
  * @description すべての Issue データを含む Atom。
- *              初期値はモックデータから取得し、rank で降順ソートされます。
+ *              初期値は空配列で、ボード（Server Component）が D1 から取得した
+ *              データで `useEffect` を介してハイドレートします。
  */
-export const issuesAtom = atom<Issue[]>(
-  mockIssues.sort((a, b) => b.rank.localeCompare(a.rank))
-);
+export const issuesAtom = atom<Issue[]>([]);
 
 /**
  * @description issuesAtom から派生し、ステータスごとに Issue をグループ化する Atom。
@@ -71,6 +89,7 @@ export const deleteIssueAtom = atom(null, (get, set, id: string) => {
   const currentIssues = get(issuesAtom);
   const updatedIssues = currentIssues.filter((issue) => issue.id !== id);
   set(issuesAtom, updatedIssues);
+  persist(deleteIssueAction(id), '課題の削除に失敗しました');
 });
 
 /**
@@ -89,6 +108,10 @@ export const updateIssueStatusAtom = atom(
       id: issueId,
       updatedIssueData: { status: newStatus },
     });
+    persist(
+      updateIssueStatusAction(issueId, newStatus.id),
+      'ステータスの更新に失敗しました'
+    );
   }
 );
 
@@ -107,6 +130,10 @@ export const updateIssuePriorityAtom = atom(
       id: issueId,
       updatedIssueData: { priority: newPriority },
     });
+    persist(
+      updateIssuePriorityAction(issueId, newPriority.id),
+      '優先度の更新に失敗しました'
+    );
   }
 );
 
@@ -125,6 +152,10 @@ export const updateIssueAssigneeAtom = atom(
       id: issueId,
       updatedIssueData: { assignees: newAssignee },
     });
+    persist(
+      updateIssueAssigneeAction(issueId, newAssignee?.id ?? null),
+      '担当者の更新に失敗しました'
+    );
   }
 );
 
@@ -147,6 +178,10 @@ export const addIssueLabelAtom = atom(
         id: issueId,
         updatedIssueData: { labels: updatedLabels },
       });
+      persist(
+        addIssueLabelAction(issueId, label.id),
+        'ラベルの追加に失敗しました'
+      );
     }
   }
 );
@@ -167,6 +202,10 @@ export const removeIssueLabelAtom = atom(
         id: issueId,
         updatedIssueData: { labels: updatedLabels },
       });
+      persist(
+        removeIssueLabelAction(issueId, labelId),
+        'ラベルの削除に失敗しました'
+      );
     }
   }
 );


### PR DESCRIPTION
Replace the Jotai in-memory mock for issues with real Cloudflare D1
persistence so created issues survive reloads and are shared across
users/devices.

Server Actions (actions/issues.ts):
- createIssue: server-side per-team sequential identifier ({teamSlug}-N,
  UNIQUE) replacing the old client-side LNUI/CIR random ids; assigns rank,
  createdBy, and writes assignee/label join rows.
- updateIssue / deleteIssue
- updateIssueStatus / updateIssuePriority (slug→id resolution)
- updateIssueAssignee (issue_assignees) / addIssueLabel / removeIssueLabel
  (issue_labels)
- updateIssueRank (issues.rank)
- getIssuesForTeam: batched board fetch (status/priority/project/assignee/
  labels) used to hydrate the board.

Authorization: all reads/writes are scoped to the current user's teams via
getCurrentUserTeamIds() (D1 has no RLS). Issue access is enforced by the
team-slug prefix of the identifier.

Frontend:
- Board page is a Server Component that loads the team's issues from D1 and
  hydrates the store (mock initialization removed; issuesAtom starts empty).
- Jotai mutation atoms now fire the matching Server Action (optimistic
  update → persist, with error toasts).
- Create modal calls createIssue and adds the confirmed issue.
- Removed the dependency on mock-data/issues.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01M5A4aLRMxHeW7W2SjL5KAd